### PR TITLE
Styles tweak

### DIFF
--- a/src/outlineView.ts
+++ b/src/outlineView.ts
@@ -229,78 +229,6 @@ function addOutlineEntries(
   }
 }
 
-const supportedTypes = [
-  "array",
-  "boolean",
-  "class",
-  "constant",
-  "constructor",
-  "enum",
-  "field",
-  "file",
-  "function",
-  "interface",
-  "method",
-  "module",
-  "namespace",
-  "number",
-  "package",
-  "property",
-  "string",
-  "variable",
-]
-
-// find better symbols for the rest
-const symbolMap = new Map([
-  // ["class", '\ue600'],
-  // ["struct", '\ue601'],
-  // ["macro", '\ue602'],
-  // ["typedef", '\ue603'],
-  // ["union", '\ue604'],
-  // ["interface", '\ue605'],
-  // ["enum", '\ue606'],
-  ["variable", "\ue607"],
-  ["function", "\ue608"],
-  ["namespace", "\ue609"],
-])
-
-// find better symbols for the rest
-const abbreviationMap = new Map([
-  ["array", "arr"],
-  ["boolean", "bool"],
-  ["class", "clas"],
-  ["constant", "cons"],
-  ["constructor", "ctor"],
-  ["enum", "enum"],
-  ["field", "fild"],
-  ["file", "file"],
-  ["function", "func"],
-  ["interface", "intf"],
-  ["method", "meth"],
-  ["module", "mod"],
-  ["namespace", "ns"],
-  ["number", "num"],
-  ["package", "pkg"],
-  ["property", "prop"],
-  ["string", "str"],
-  ["variable", "var"],
-])
-
-function getIconHTML(type: string | undefined) {
-  if (type) {
-    if (symbolMap.has(type)) {
-      return `<span style="font-family: 'symbol-icons';">${symbolMap.get(type)}</span>`
-    }
-    if (abbreviationMap.has(type)) {
-      return `<span>${abbreviationMap.get(type)}</span>`
-    } else {
-      return `<span>${type.substring(0, 3)}</span>`
-    }
-  } else {
-    return "<span>•</span>"
-  }
-}
-
 function getIcon(iconType?: string, kindType?: string) {
   // LSP specification: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentSymbol
   // atom-languageclient mapping: https://github.com/atom/atom-languageclient/blob/485bb9d706b422456640c9070eee456ef2cf09c0/lib/adapters/outline-view-adapter.ts#L270
@@ -313,7 +241,7 @@ function getIcon(iconType?: string, kindType?: string) {
     kindType = iconType
   }
 
-  let type: string | undefined
+  let type: string = "•"
   if (typeof kindType === "string" && kindType.length > 0) {
     let kindClass: string
     // hasKind
@@ -321,18 +249,15 @@ function getIcon(iconType?: string, kindType?: string) {
       // supplied with type-...
       kindClass = `${kindType}`
       type = kindType.replace("type-", "")
-    } else if (supportedTypes.includes(kindType)) {
+    } else {
       // supplied without type-
       kindClass = `type-${kindType}`
       type = kindType
-    } else {
-      // as is
-      kindClass = kindType
     }
     iconElement.classList.add(kindClass)
   }
 
-  iconElement.innerHTML = getIconHTML(type)
+  iconElement.innerHTML = `<span>${type.substring(0, 3)}</span>`
 
   return iconElement
 }

--- a/src/outlineView.ts
+++ b/src/outlineView.ts
@@ -262,7 +262,7 @@ function getIcon(iconType?: string, kindType?: string) {
   return iconElement
 }
 
-const foldButtonWidth = 20
+const foldButtonWidth = 25 // from css: .fold witdth + .fold margin-right
 
 function createFoldButton(childrenList: HTMLUListElement, foldInitially: boolean) {
   // TIME: ~0.1-0.5ms

--- a/src/outlineView.ts
+++ b/src/outlineView.ts
@@ -234,7 +234,7 @@ function getIcon(iconType?: string, kindType?: string) {
   // atom-languageclient mapping: https://github.com/atom/atom-languageclient/blob/485bb9d706b422456640c9070eee456ef2cf09c0/lib/adapters/outline-view-adapter.ts#L270
 
   const iconElement = document.createElement("span")
-  iconElement.classList.add("icon")
+  iconElement.classList.add("outline-icon")
 
   // if iconType given instead
   if (kindType == undefined && iconType != undefined) {
@@ -272,9 +272,9 @@ function createFoldButton(childrenList: HTMLUListElement, foldInitially: boolean
   if (foldInitially) {
     // collapse in large files by default
     childrenList.hidden = true
-    foldButton.classList.add("fold", "collapsed")
+    foldButton.classList.add("outline-fold-btn", "collapsed")
   } else {
-    foldButton.classList.add("fold", "expanded")
+    foldButton.classList.add("outline-fold-btn", "expanded")
   }
 
   // fold listener

--- a/src/outlineView.ts
+++ b/src/outlineView.ts
@@ -262,7 +262,7 @@ function getIcon(iconType?: string, kindType?: string) {
   return iconElement
 }
 
-const foldButtonWidth = 25 // from css: .fold witdth + .fold margin-right
+const foldButtonWidth = 20
 
 function createFoldButton(childrenList: HTMLUListElement, foldInitially: boolean) {
   // TIME: ~0.1-0.5ms

--- a/styles/atom-ide-outline.less
+++ b/styles/atom-ide-outline.less
@@ -51,7 +51,7 @@
     }
   }
 
-  .fold {
+  .outline-fold-btn {
     contain: @contain_except_size;
     display: inline-block;
     position: relative;
@@ -81,7 +81,7 @@
     }
   }
 
-  .icon {
+  .outline-icon {
     contain: @contain_except_size;
     display: inline-block;
     width: 5ch;

--- a/styles/atom-ide-outline.less
+++ b/styles/atom-ide-outline.less
@@ -84,7 +84,7 @@
   .icon {
     contain: @contain_except_size;
     display: inline-block;
-    width: 5ex;
+    width: 5ch;
     font-size: 75%;
     text-align: center;
     vertical-align: middle; // align icon with text vertically

--- a/styles/atom-ide-outline.less
+++ b/styles/atom-ide-outline.less
@@ -84,7 +84,7 @@
   .outline-icon {
     contain: @contain_except_size;
     display: inline-block;
-    width: 5ch;
+    width: 6ch;
     font-size: 75%;
     text-align: center;
     vertical-align: middle; // align icon with text vertically

--- a/styles/atom-ide-outline.less
+++ b/styles/atom-ide-outline.less
@@ -95,7 +95,7 @@
   // atom-languageclient mapping: https://github.com/atom/atom-languageclient/blob/485bb9d706b422456640c9070eee456ef2cf09c0/lib/adapters/outline-view-adapter.ts#L270
 
   .iconByType(@type) {
-    content: replace(@type, "^(....).*$", '"$1"');
+    content: replace(@type, "^(....).*$", '"$1"'); // use the first 4 letter of the type
   }
   .iconByType(array) {
     content: "arr";

--- a/styles/atom-ide-outline.less
+++ b/styles/atom-ide-outline.less
@@ -55,11 +55,7 @@
     contain: @contain_except_size;
     display: inline-block;
     position: relative;
-
-    // edit foldButtonWidth in outlineView.ts if you changed this
     width: 20px;
-    margin-right: 5px;
-
     padding-left: 7px;
     padding-right: 0;
     opacity: 1;

--- a/styles/atom-ide-outline.less
+++ b/styles/atom-ide-outline.less
@@ -92,11 +92,57 @@
   // syntax-variables for languge entites: https://github.com/atom/atom/blob/master/static/variables/syntax-variables.less#L32
   // atom-languageclient mapping: https://github.com/atom/atom-languageclient/blob/485bb9d706b422456640c9070eee456ef2cf09c0/lib/adapters/outline-view-adapter.ts#L270
 
+  .iconByType(@type) {
+    content: replace(@type, "^(....).*$", '"$1"');
+  }
+  .iconByType(array) {
+    content: "arr";
+  }
+  .iconByType(constructor) {
+    content: "ctor";
+  }
+  .iconByType(field) {
+    content: "fild";
+  }
+  .iconByType(function) {
+    font-family: "symbol-icons";
+    content: "\e608";
+  }
+  .iconByType(interface) {
+    content: "intf";
+  }
+  .iconByType(module) {
+    content: "mod";
+  }
+  .iconByType(namespace) {
+    font-family: "symbol-icons";
+    content: "\e609";
+  }
+  .iconByType(number) {
+    content: "num";
+  }
+  .iconByType(package) {
+    content: "pkg";
+  }
+  .iconByType(string) {
+    content: "str";
+  }
+  .iconByType(variable) {
+    font-family: "symbol-icons";
+    content: "\e607";
+  }
+
   .styleByType(@type, @color) {
     .type-@{type} {
       contain: @contain_except_size;
       color: @color;
       font-size: smaller;
+      &::before {
+        .iconByType(@type);
+      }
+      & > span {
+        display: none;
+      }
     }
 
     .fold-type-@{type} {

--- a/styles/atom-ide-outline.less
+++ b/styles/atom-ide-outline.less
@@ -83,9 +83,10 @@
   .icon {
     contain: @contain_except_size;
     display: inline-block;
-    width: 40px;
+    width: 5ex;
+    font-size: 75%;
     text-align: center;
-    vertical-align: top; // align icon with text vertically
+    vertical-align: middle; // align icon with text vertically
     font-weight: normal;
   }
 
@@ -134,9 +135,7 @@
 
   .styleByType(@type, @color) {
     .type-@{type} {
-      contain: @contain_except_size;
       color: @color;
-      font-size: smaller;
       &::before {
         .iconByType(@type);
       }

--- a/styles/atom-ide-outline.less
+++ b/styles/atom-ide-outline.less
@@ -34,6 +34,7 @@
       display: inline-block;
       width: 100%;
       padding: 2px 5px;
+      white-space: nowrap;
 
       // highlight on hover
       &:hover {

--- a/styles/atom-ide-outline.less
+++ b/styles/atom-ide-outline.less
@@ -55,7 +55,11 @@
     contain: @contain_except_size;
     display: inline-block;
     position: relative;
+
+    // edit foldButtonWidth in outlineView.ts if you changed this
     width: 20px;
+    margin-right: 5px;
+
     padding-left: 7px;
     padding-right: 0;
     opacity: 1;


### PR DESCRIPTION
The primary thing this PR does is changes icon width from fixed 40px to `5ex` and font-size from `smaller` to the more specific `75%`. The reason is very straightforward: editor font size is arbitrary, so we can't rely on that.

| Before | After |
|----------|--------|
|![image](https://user-images.githubusercontent.com/7275622/111021922-99223180-83e0-11eb-95e7-69232540ca3a.png) | ![image](https://user-images.githubusercontent.com/7275622/111021902-798b0900-83e0-11eb-8af3-49858dbc61eb.png) |


Also disables line-wrapping on outline items to avoid breaking up icons and the following text. Arguably line-wrapping was never the intention since most identifiers don't contain whitespace anyway.

Aside from minor cosmetic tweaks, this PR also moves most icon style logic into the less file. There are tantalizing reasons to want to move icon style management into styles: for one, everything ends up in the one place, and for two, it's way more customizable that way. However, this changes the behaviour slightly: previously, known `type`s were prefixed with `type-`. Now every kind is prefixed with `type-`. I don't know if anything actually uses this, if it is, let me know, I'll revert some changes to keep this behaviour as-is