### PR TITLE
Fix initial outline

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
-import { CompositeDisposable, TextEditor, CursorPositionChangedEvent } from "atom"
+import { CompositeDisposable, TextEditor } from "atom"
 import { OutlineView } from "./outlineView"
-import { OutlineProvider, BusySignalRegistry, BusySignalProvider } from "atom-ide-base"
+import { OutlineProvider } from "atom-ide-base"
 import { ProviderRegistry } from "atom-ide-base/commons-atom/ProviderRegistry"
 
 export { statuses } from "./statuses" // for spec

--- a/src/main.ts
+++ b/src/main.ts
@@ -92,7 +92,7 @@ async function editorChanged(editor?: TextEditor) {
   // A high number will increase the responsiveness of the text editor in large files.
   const updateDebounceTime = Math.max(lineCount / 5, 300) // 1/5 of the line count
 
-  const doubouncedGetOutline = debounce(getOutline as (editor: TextEditor) => Promise<void>, updateDebounceTime)
+  const doubouncedGetOutline = debounce(getOutline as (textEditor: TextEditor) => Promise<void>, updateDebounceTime)
 
   onDidCompositeDisposable!.add(
     // update the outline if editor stops changing

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -26,7 +26,8 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "importHelpers": false,
-    "outDir": "../dist"
+    "outDir": "../dist",
+    "skipLibCheck": true
   },
   "compileOnSave": false
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,3 +12,11 @@ export function isItemVisible(item: object) {
     return true
   }
 }
+
+/** Throw an Error using atom notifications */
+export function notifyError(e: Error) {
+  atom.notifications.addError(e.name, {
+    stack: e.stack,
+    detail: e.message,
+  })
+}


### PR DESCRIPTION
I've cherry-picked two first commits from the other PR. This should be more or less uncontroversial, and I will rebase the other PR later.

This is a hacky way to fix #94 -- basically it emulates editor change whenever an outline is shown. The issue is editor change is aborted early if outline is not visible (which is entirely reasonable), so when it is shown, we need to retrigger the event.

It's not particularly pretty, but it works.

I'm not sure how to reliably test for this and not convinced it's worth the effort to try to add such a test. Mocking an outline provider might be one way to get repeatable results, but that's a lot of work for one test. Let me know what you think.