### PR TITLE
fix: outline getting stuck on "no provider"

### DIFF
--- a/src/outlineView.ts
+++ b/src/outlineView.ts
@@ -75,6 +75,7 @@ export class OutlineView {
     if (this.outlineList !== undefined) {
       this.outlineList.dataset.editorRootScope = ""
     }
+    this.lastEntries = undefined
   }
 
   presentStatus(status: { title: string; description: string }) {


### PR DESCRIPTION
Outline was getting stuck on "no provider" when changing editors. The reason is this line
https://github.com/atom-community/atom-ide-outline/blob/3f8f7d07d7b22c73d29429467a7f7dc82311bb39/src/outlineView.ts#L49
in combination with `presentStatus` never resetting `this.lastEntries`.

Edit: since it's not obvious from the diff, I've added `this.lastEntries = undefined` to `clearContent()`.