### PR TITLE
fix: add an internal debounce to setOutline + move code to OutlineView [skip release]

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "test.format": "prettier . --check",
     "lint": "eslint . --fix",
     "test.lint": "eslint .",
-    "test": "atom --test spec",
+    "test": "npm run clean && cross-env NODE_ENV=test rollup -c && atom --test spec",
     "clean": "shx rm -rf dist",
     "dev": "npm run clean && cross-env NODE_ENV=development rollup -c -w",
-    "build": "npm run clean && cross-env NODE_ENV=production rollup -c ",
+    "build": "npm run clean && cross-env NODE_ENV=production rollup -c",
     "build-commit": "build-commit -o dist",
     "bump": "ncu -u",
     "prepare": "npm run build"

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,7 +52,7 @@ export function deactivate() {
 //   subscriptions.add(busySignalProvider)
 // }
 
-export function consumeOutlineProvider(provider: OutlineProvider) {
+export async function consumeOutlineProvider(provider: OutlineProvider) {
   subscriptions.add(/*  providerRegistryEntry */ outlineProviderRegistry.addProvider(provider))
 
   // NOTE Generate (try) an outline after obtaining a provider for the current active editor
@@ -61,13 +61,13 @@ export function consumeOutlineProvider(provider: OutlineProvider) {
   // or if the editor changes later once outline is visible
   // so we need to have an outline for the current editor
   // the following updates rely on the visibility
-  getOutline()
+  await getOutline()
 }
 
 // disposables returned inside onEditorChangedDisposable
 let onEditorChangedDisposable: CompositeDisposable | undefined = undefined
 
-function editorChanged(editor?: TextEditor) {
+async function editorChanged(editor?: TextEditor) {
   if (editor === undefined) {
     return
   }
@@ -79,7 +79,7 @@ function editorChanged(editor?: TextEditor) {
   // this is because we can't track if the outline tab becomes visible suddenly,
   // so we always need to show the outline for the correct file
   // the following updates rely on the visibility
-  getOutline(editor)
+  await getOutline(editor)
 
   const largeness = editorLargeness(editor as TextEditor)
   // How long to wait for the new changes before updating the outline.
@@ -154,7 +154,7 @@ export function getOutline(editor = atom.workspace.getActiveTextEditor()) {
   if (view === undefined) {
     view = new OutlineView() // create outline pane
   }
-  view.setOutline(editor)
+  return view.setOutline(editor)
 }
 
 export { default as config } from "./config.json"

--- a/src/outlineView.ts
+++ b/src/outlineView.ts
@@ -23,7 +23,7 @@ export class OutlineView {
   private setOutlineTimeout: NodeJS.Timeout | undefined
   private isRendering: boolean = false
 
-  constructor() {
+  public constructor() {
     this.element = document.createElement("div")
     this.element.classList.add("atom-ide-outline")
 
@@ -35,23 +35,23 @@ export class OutlineView {
     this.outlineContent.classList.add("outline-content")
   }
 
-  destroy() {
+  public destroy() {
     this.element.remove()
   }
 
-  getElement() {
+  public getElement() {
     return this.element
   }
 
-  getTitle() {
+  public getTitle() {
     return "Outline"
   }
 
-  getIconName() {
+  public getIconName() {
     return "list-unordered"
   }
 
-  setOutline(editor: TextEditor | undefined) {
+  public setOutline(editor: TextEditor | undefined) {
     if (this.isRendering) {
       // return if setOutline is already called and not finished yet.
       return
@@ -111,7 +111,7 @@ export class OutlineView {
     this.isRendering = false
   }
 
-  clearContent() {
+  private clearContent() {
     this.outlineContent.innerHTML = ""
     if (this.outlineList !== undefined) {
       this.outlineList.dataset.editorRootScope = ""
@@ -119,12 +119,12 @@ export class OutlineView {
     this.lastEntries = undefined
   }
 
-  setStatus(id: "noEditor" | "noProvider") {
+  public setStatus(id: "noEditor" | "noProvider") {
     this.presentStatus(statuses[id])
     this.isRendering = false
   }
 
-  presentStatus(status: { title: string; description: string }) {
+  private presentStatus(status: { title: string; description: string }) {
     this.clearContent()
 
     const statusElement = status && generateStatusElement(status)
@@ -135,7 +135,7 @@ export class OutlineView {
   }
 
   // callback for scrolling and highlighting the element that the cursor is on
-  selectAtCursorLine(editor: TextEditor) {
+  public selectAtCursorLine(editor: TextEditor) {
     const cursor = editor.getLastCursor()
 
     // no cursor


### PR DESCRIPTION
`setOutline` was being called multiple times because of having different observers that were calling it.